### PR TITLE
Query without search_quantities

### DIFF
--- a/src/nomad_polymerization_reactions/schema_packages/polymerization.py
+++ b/src/nomad_polymerization_reactions/schema_packages/polymerization.py
@@ -270,13 +270,8 @@ class PolymerizationReaction(Activity, Schema):
         search_result = search(
             owner='visible',
             query={
-                'search_quantities': {
-                    'id': (
-                        'data.smiles#nomad_polymerization_reactions.schema_packages'
-                        '.polymerization.Monomer'
-                    ),
-                    'str_value': f'{smiles}',
-                }
+                'data.smiles#nomad_polymerization_reactions.schema_packages.'
+                'polymerization.Monomer': smiles
             },
             user_id=archive.metadata.main_author.user_id,
         ).data


### PR DESCRIPTION
Queries based on `search_quantities` are broken down into tokens. For SMILES, the presence of special tokens complicates the process even further.

On the other hand, `nomad.search` now supports querying quantities in the `data` section directly based on the quantity id. Using that here.