### PR TITLE
Use topology section for monomer visualization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "click>=7.1.2",
     "nomad-lab>=1.4.0",
     "numpy>=1.22.4",
-    "plotly<6",
     "pydantic>=2",
     "pyyaml>=6.0",
     "structlog",

--- a/src/nomad_polymerization_reactions/schema_packages/polymerization.py
+++ b/src/nomad_polymerization_reactions/schema_packages/polymerization.py
@@ -402,9 +402,6 @@ class Monomer(PureSubstance, Schema):
 
         self.populate_topology(archive, logger)
 
-        fig = self.generate_visualization()
-        self.figures = [fig] if fig else []
-
         super().normalize(archive, logger)
 
 

--- a/src/nomad_polymerization_reactions/schema_packages/polymerization.py
+++ b/src/nomad_polymerization_reactions/schema_packages/polymerization.py
@@ -325,8 +325,8 @@ class Monomer(PureSubstance, Schema):
 
     def populate_topology(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         """
-        Populates the `topology` section with elements and atomic positions from the
-        xTB features.
+        Populates the `archive.results.material` section with elements and topology
+        using the atomic positions from xTB features.
         """
         if not self.xtb_features or not self.xtb_features.atomic_features:
             return

--- a/src/nomad_polymerization_reactions/schema_packages/polymerization.py
+++ b/src/nomad_polymerization_reactions/schema_packages/polymerization.py
@@ -4,11 +4,8 @@ from typing import (
 from urllib.parse import quote
 
 import numpy as np
-import plotly.graph_objects as go
 from ase import Atoms
-from ase.data import chemical_symbols, covalent_radii
-from ase.data.colors import jmol_colors
-from ase.neighborlist import NeighborList, natural_cutoffs
+from ase.data import chemical_symbols
 from nomad.datamodel.data import ArchiveSection, Schema
 from nomad.datamodel.metainfo.annotations import ELNAnnotation, ELNComponentEnum
 from nomad.datamodel.metainfo.basesections import (
@@ -297,7 +294,7 @@ class XTBFeatures(ArchiveSection):
     )
 
 
-class Monomer(PureSubstance, Schema, PlotSection):
+class Monomer(PureSubstance, Schema):
     """
     Schema for monomer data in polymerization reactions.
     """
@@ -325,107 +322,6 @@ class Monomer(PureSubstance, Schema, PlotSection):
         description='xTB calculated features of the monomer.',
         section_def=XTBFeatures,
     )
-
-    def generate_visualization(self) -> PlotlyFigure | None:
-        """
-        Generate a 3D visualization of the monomer from its atomic positions.
-
-        Uses ASE for atom data and bond detection (via natural cutoff neighbor
-        list). Renders a Plotly 3D scatter with Jmol colors and sizes based on covalent
-        radii.
-        """
-
-        if not self.xtb_features or not self.xtb_features.atomic_features:
-            return None
-
-        elements = []
-        positions = []
-        for atom in self.xtb_features.atomic_features:
-            if atom.element is None or atom.positions is None:
-                continue
-            elements.append(atom.element)
-            positions.append(atom.positions.to('angstrom').magnitude)
-
-        if not positions:
-            return None
-
-        atoms = Atoms(symbols=elements, positions=positions)
-        pos = atoms.get_positions()
-        x, y, z = pos[:, 0], pos[:, 1], pos[:, 2]
-
-        # Colors from ASE's Jmol palette, sizes from covalent radii
-        # Override white (H) to light grey for visibility
-        def atom_color(atomic_number: int) -> str:
-            grey_cutoff = 0.95
-            r, g, b = jmol_colors[atomic_number]
-            if r > grey_cutoff and g > grey_cutoff and b > grey_cutoff:
-                return 'rgb(200, 200, 200)'
-            return f'rgb({int(r * 255)}, {int(g * 255)}, {int(b * 255)})'
-
-        colors = [atom_color(a.number) for a in atoms]
-        sizes = [max(6, covalent_radii[a.number] * 18) for a in atoms]
-
-        # Atom trace
-        atom_trace = go.Scatter3d(
-            x=x,
-            y=y,
-            z=z,
-            mode='markers+text',
-            marker=dict(
-                size=sizes,
-                color=colors,
-                line=dict(width=1, color='#333333'),
-            ),
-            text=elements,
-            textposition='top center',
-            textfont=dict(size=9),
-            hovertext=[
-                f'{s} ({xi:.3f}, {yi:.3f}, {zi:.3f})'
-                for s, xi, yi, zi in zip(elements, x, y, z)
-            ],
-            hoverinfo='text',
-            name='atoms',
-        )
-
-        # Bond detection using ASE neighbor list
-        cutoffs = natural_cutoffs(atoms)
-        nl = NeighborList(cutoffs, self_interaction=False, bothways=False)
-        nl.update(atoms)
-
-        bond_x, bond_y, bond_z = [], [], []
-        for i in range(len(atoms)):
-            indices, _ = nl.get_neighbors(i)
-            for j in indices:
-                bond_x.extend([x[i], x[j], None])
-                bond_y.extend([y[i], y[j], None])
-                bond_z.extend([z[i], z[j], None])
-
-        bond_trace = go.Scatter3d(
-            x=bond_x,
-            y=bond_y,
-            z=bond_z,
-            mode='lines',
-            line=dict(color='#555555', width=4),
-            hoverinfo='none',
-            name='bonds',
-        )
-
-        fig = go.Figure(data=[bond_trace, atom_trace])
-        fig.update_layout(
-            scene=dict(
-                xaxis_title='x (Å)',
-                yaxis_title='y (Å)',
-                zaxis_title='z (Å)',
-                aspectmode='data',
-            ),
-            showlegend=False,
-            margin=dict(l=0, r=0, t=40, b=0),
-        )
-
-        return PlotlyFigure(
-            label='Best conformer visualization generated from xTB features.',
-            figure=fig.to_plotly_json(),
-        )
 
     def populate_topology(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         """

--- a/src/nomad_polymerization_reactions/schema_packages/polymerization.py
+++ b/src/nomad_polymerization_reactions/schema_packages/polymerization.py
@@ -18,9 +18,11 @@ from nomad.datamodel.metainfo.basesections import (
     PublicationReference,
 )
 from nomad.datamodel.metainfo.basesections.v1 import PureSubstance, SectionReference
-from nomad.datamodel.metainfo.plot import PlotlyFigure, PlotSection
+from nomad.datamodel.results import Material, System
 from nomad.metainfo import MEnum, Quantity, SchemaPackage, SubSection
 from nomad.metainfo.metainfo import Section
+from nomad.normalizing.common import nomad_atoms_from_ase_atoms
+from nomad.normalizing.topology import add_system, add_system_info
 
 if TYPE_CHECKING:
     from nomad.datamodel.datamodel import (
@@ -425,6 +427,46 @@ class Monomer(PureSubstance, Schema, PlotSection):
             figure=fig.to_plotly_json(),
         )
 
+    def populate_topology(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+        """
+        Populates the `topology` section with elements and atomic positions from the
+        xTB features.
+        """
+        if not self.xtb_features or not self.xtb_features.atomic_features:
+            return
+
+        elements = []
+        positions = []
+        for atom in self.xtb_features.atomic_features:
+            if atom.element is None or atom.positions is None:
+                continue
+            elements.append(atom.element)
+            positions.append(atom.positions.to('angstrom').magnitude)
+
+        if not positions:
+            return None
+
+        atoms = Atoms(symbols=elements, positions=positions)
+
+        material = Material()
+        material.elements = list(elements)
+        topology = {}
+        system = System(
+            atoms=nomad_atoms_from_ase_atoms(atoms),
+            label=atoms.get_chemical_formula(),
+            description='Structure based on xTB features of the best conformer of the '
+            'molecule.',
+            structural_type='monomer',
+            dimensionality='3D',
+        )
+        add_system_info(system, topology)
+        add_system(system, topology)
+
+        material.topology = list(topology.values())
+
+        archive.m_setdefault('results.material')
+        archive.results.material = material
+
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         """
         Populates the `pure_substance` section with data from PubChem based on the
@@ -461,6 +503,8 @@ class Monomer(PureSubstance, Schema, PlotSection):
             pure_substance.smile = self.smiles
         if pure_substance:
             self.pure_substance = pure_substance
+
+        self.populate_topology(archive, logger)
 
         fig = self.generate_visualization()
         self.figures = [fig] if fig else []


### PR DESCRIPTION
This pull request refactors the `Monomer` section to remove its dependency on custom Plotly-based visualization and instead populate the `topology` section with structural information using NOMAD's material and system schema. Once `topology` section is populated, "Material" card is generated by downstream processing to create a NOMAD standard visualization of the monomer.

Current custom visualization is also misleading as it also plots the connectivity. Since there is no information about the type of covalent bond (single, double, triple), the visualization only has a single-line connectivity, which can be misinterpreted as single bond. The standard visualization from NOMAD does not have atom connectivity. A conservative approach is better than a misleading one.