### PR TITLE
Improve monomer normalization

### DIFF
--- a/src/nomad_polymerization_reactions/schema_packages/polymerization.py
+++ b/src/nomad_polymerization_reactions/schema_packages/polymerization.py
@@ -370,16 +370,12 @@ class Monomer(PureSubstance, Schema):
         Generates a 3D visualization of the monomer if atomic positions are available
         from the xTB features.
         """
-        if not self.name:
-            self.name = 'Monomer'
 
         # reset `archive.results.material` section to be repopulated from
         # `PureSubstance` normalization
         if archive.results and archive.results.material:
             archive.results.material = None
         archive.m_setdefault('results.material')
-        if self.name != 'Monomer':
-            archive.results.material.material_name = self.name
 
         self.components = []
         self.elemental_composition = []
@@ -395,6 +391,10 @@ class Monomer(PureSubstance, Schema):
             pure_substance.smile = self.smiles
         if pure_substance:
             self.pure_substance = pure_substance
+            if self.pure_substance.name:
+                archive.results.material.material_name = self.pure_substance.name
+                if not self.name:
+                    self.name = self.pure_substance.name
 
         self.populate_topology(archive, logger)
 

--- a/src/nomad_polymerization_reactions/schema_packages/polymerization.py
+++ b/src/nomad_polymerization_reactions/schema_packages/polymerization.py
@@ -364,11 +364,9 @@ class Monomer(PureSubstance, Schema):
         Populates the `pure_substance` section with data from PubChem based on the
         `smiles` quantity.
 
-        Resets the `archive.results.material` section with the monomer name, if
-        provided.
-
-        Generates a 3D visualization of the monomer if atomic positions are available
-        from the xTB features.
+        Resets the `archive.results.material` section based on `pure_substance` and
+        `xtb_features`. Populating `archive.results.material.topology` creates a
+        visualization of the monomer in the material card.
         """
 
         # reset `archive.results.material` section to be repopulated from
@@ -377,9 +375,7 @@ class Monomer(PureSubstance, Schema):
             archive.results.material = None
         archive.m_setdefault('results.material')
 
-        self.components = []
         self.elemental_composition = []
-        pure_substance = None
         if self.smiles:
             # Use URL-encoded SMILES to handle special characters properly when
             # fetching from PubChem. Can be removed once `PubChemPureSubstanceSection`
@@ -389,7 +385,7 @@ class Monomer(PureSubstance, Schema):
             )
             pure_substance.normalize(archive, logger)
             pure_substance.smile = self.smiles
-        if pure_substance:
+
             self.pure_substance = pure_substance
             if self.pure_substance.name:
                 archive.results.material.material_name = self.pure_substance.name


### PR DESCRIPTION
- The logic for setting the monomer/material name has been updated: if a name is available from `pure_substance`, it is used for both `archive.results.material.material_name` and the schema's `name` field, ensuring consistency with PubChem data.
- Redundant code for handling `components`  and the default monomer name has been removed