### PR TITLE
URL-safe PubChem call fix moved in basesections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "ase>=3.25.0",
     "click>=7.1.2",
-    "nomad-lab>=1.4.0",
+    "nomad-lab>=1.4.3",
     "numpy>=1.22.4",
     "pydantic>=2",
     "pyyaml>=6.0",

--- a/src/nomad_polymerization_reactions/schema_packages/polymerization.py
+++ b/src/nomad_polymerization_reactions/schema_packages/polymerization.py
@@ -1,7 +1,6 @@
 from typing import (
     TYPE_CHECKING,
 )
-from urllib.parse import quote
 
 import numpy as np
 from ase import Atoms
@@ -377,14 +376,8 @@ class Monomer(PureSubstance, Schema):
 
         self.elemental_composition = []
         if self.smiles:
-            # Use URL-encoded SMILES to handle special characters properly when
-            # fetching from PubChem. Can be removed once `PubChemPureSubstanceSection`
-            # implements URL encoding.
-            pure_substance = PubChemPureSubstanceSection(
-                smile=quote(self.smiles, safe='')
-            )
+            pure_substance = PubChemPureSubstanceSection(smile=self.smiles)
             pure_substance.normalize(archive, logger)
-            pure_substance.smile = self.smiles
 
             self.pure_substance = pure_substance
             if self.pure_substance.name:


### PR DESCRIPTION
To be merged, once the `nomad-lab==1.4.3` is released with the [fix](https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/3055).